### PR TITLE
Simple Remote Access Scripts

### DIFF
--- a/www/regenerate-index.sh
+++ b/www/regenerate-index.sh
@@ -1,0 +1,23 @@
+rm ~/myopenaps/enact/index.html
+(echo '<meta http-equiv="refresh" content="60">') > ~/myopenaps/enact/index.html
+(echo '<html>') >> ~/myopenaps/enact/index.html
+(echo '<body>') >> ~/myopenaps/enact/index.html
+(echo '<style>table,th,td {border: 1px solid black;}th,td {padding: 4px;}</style>') >> ~/myopenaps/enact/index.html
+(echo '<table>') >> ~/myopenaps/enact/index.html
+(echo '<tr>') >> ~/myopenaps/enact/index.html
+(echo '<th>Parameter</th><th>Value</th>') >> ~/myopenaps/enact/index.html
+(echo '</tr>') >> ~/myopenaps/enact/index.html
+
+(echo '<tr>') >> ~/myopenaps/enact/index.html
+(echo -n '<td>Page updated</td><td>') >> ~/myopenaps/enact/index.html
+date >> ~/myopenaps/enact/index.html
+(echo '</td></tr>') >> ~/myopenaps/enact/index.html
+
+(echo '<tr>') >> ~/myopenaps/enact/index.html
+(echo -n '<td>Edison Battery</td><td>'
+cat ~/myopenaps/monitor/edison-battery.json | jq -r .battery | tr '\n' ' ' && echo '%') >> ~/myopenaps/enact/index.html
+(echo '</td></tr>') >> ~/myopenaps/enact/index.html
+
+(echo '</table>') >> ~/myopenaps/enact/index.html
+(echo '</body>') >> ~/myopenaps/enact/index.html
+(echo '</html>') >> ~/myopenaps/enact/index.html

--- a/www/setup-http.sh
+++ b/www/setup-http.sh
@@ -1,0 +1,2 @@
+(crontab -l; crontab -l | grep -q "SimpleHTTPServer" || echo '@reboot cd /root/myopenaps/enact && python -m SimpleHTTPServer 1337 > /dev/null 2>&1') | crontab -
+(crontab -l; crontab -l | grep -q "regenerate-index" || echo '*/1 * * * * (bash /root/myopenaps/enact/regenerate-index.sh) 2>&1 | tee -a /var/log/openaps/http.log') | crontab -


### PR DESCRIPTION
regenerate-index.sh creates a new file index.html every time it is run.  This contains simple html formatting with example data for now (intent is to add additional parameter-value pairs for display after approval of proof of concept).
setup-http.sh is intended to be called from oref0-setup.sh and adds cron entries to start SimpleHTTPServer at reboot and run regenerate-index.sh periodically.  Both files should be in ~/myopenaps/enact directory.  From a browser on any device, browse to http://[RIG_IP_ADDRESS]/index.html and the page will self-refresh periodically.